### PR TITLE
chore: Updated bluid.gradle compileSdkVersion from 30 to 31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
The last update from **snowplow-android-tracker** was released 6 days ago, and the [snowplow-flutter-tracker](https://github.com/snowplow-incubator/snowplow-flutter-tracker) had the build broken.

The snowplow-android-tracker made a update of `compileSdkVersion` from 30 to 31, you can see it below
https://github.com/snowplow/snowplow-android-tracker/commits/master/snowplow-tracker/build.gradle

So i had to do the same on [snowplow-flutter-tracker](https://github.com/snowplow-incubator/snowplow-flutter-tracker).

Thanks