### PR TITLE
Enable screen and application context on mobile (close #27)

### DIFF
--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/configurations/TrackerConfigurationReader.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/configurations/TrackerConfigurationReader.kt
@@ -25,6 +25,8 @@ class TrackerConfigurationReader(values: Map<String, Any>) {
     val platformContext: Boolean? by valuesDefault
     val geoLocationContext: Boolean? by valuesDefault
     val sessionContext: Boolean? by valuesDefault
+    val screenContext: Boolean? by valuesDefault
+    val applicationContext: Boolean? by valuesDefault
 
     fun toConfiguration(context: Context): TrackerConfiguration {
         val trackerConfig = DefaultTrackerConfiguration.toConfiguration(appId, context)
@@ -45,6 +47,8 @@ class TrackerConfigurationReader(values: Map<String, Any>) {
         platformContext?.let { trackerConfig.platformContext(it) }
         geoLocationContext?.let { trackerConfig.geoLocationContext(it) }
         sessionContext?.let { trackerConfig.sessionContext(it) }
+        screenContext?.let { trackerConfig.screenContext(it) }
+        applicationContext?.let { trackerConfig.applicationContext(it) }
 
         return trackerConfig
     }
@@ -54,9 +58,7 @@ object DefaultTrackerConfiguration {
     fun toConfiguration(appId: String?, context: Context): TrackerConfiguration {
         val trackerConfig = TrackerConfiguration(appId ?: context.getPackageName())
                 .trackerVersionSuffix(TrackerVersion.TRACKER_VERSION)
-
-        trackerConfig.applicationContext(false)
-        trackerConfig.screenContext(false)
+        
         trackerConfig.screenViewAutotracking(false)
         trackerConfig.lifecycleAutotracking(false)
         trackerConfig.installAutotracking(false)

--- a/doc/02-configuration.md
+++ b/doc/02-configuration.md
@@ -37,10 +37,12 @@ Setting a custom POST path can be useful in avoiding adblockers; it replaces the
 | `appId` | `String?` | Identifier of the app. | ✔ | ✔ | ✔ | null on Web, bundle identifier on iOS/Android |
 | `devicePlatform` | `DevicePlatform?` | The device platform the tracker runs on. Available options are provided by the `DevicePlatform` enum. | ✔ | ✔ | ✔ | "web" on Web, "mob" on iOS/Android |
 | `base64Encoding` | `bool?` | Indicates whether payload JSON data should be base64 encoded. | ✔ | ✔ | ✔ | true |
-| `platformContext` | `bool?` | Indicates whether platform context should be attached to tracked events. | ✔ | ✔ | | true |
-| `geoLocationContext` | `bool?` | Indicates whether geo-location context should be attached to tracked events. | ✔ | ✔ | ✔ | false |
-| `sessionContext` | `bool?` | Indicates whether session context should be attached to tracked events. | ✔ | ✔ | ✔ | true |
-| `webPageContext` | `bool?` | Indicates whether context about current web page should be attached to tracked events. | | | ✔ | true |
+| `platformContext` | `bool?` | Indicates whether [platform](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2) (mobile) context should be attached to tracked events. | ✔ | ✔ | | true |
+| `geoLocationContext` | `bool?` | Indicates whether [geo-location](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/geolocation_context/jsonschema/1-1-0) context should be attached to tracked events. | ✔ | ✔ | ✔ | false |
+| `sessionContext` | `bool?` | Indicates whether [session](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2) context should be attached to tracked events. | ✔ | ✔ | ✔ | true |
+| `webPageContext` | `bool?` | Indicates whether context about current [web page](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0) should be attached to tracked events. | | | ✔ | true |
+| `screenContext` | `bool?` | Indicates whether [screen](http://iglucentral.com/schemas/com.snowplowanalytics.mobile/screen/jsonschema/1-0-0) context should be attached to tracked events. | ✔ | ✔ | | true |
+| `applicationContext` | `bool?` | Indicates whether [application](http://iglucentral.com/schemas/com.snowplowanalytics.mobile/application/jsonschema/1-0-0) context should be attached to tracked events. | ✔ | ✔ | | true |
 | `webActivityTracking` | WebActivityTracking?` | Enables activity tracking using page views and pings on the Web. | | | ✔ | true |
 
 The optional `WebActivityTracking` property configures page tracking on Web. Initializing the configuration will inform `SnowplowObserver` observers (see section on auto-tracking in "Tracking events") to auto track `PageViewEvent` events instead of `ScreenView` events on navigation changes. Further, setting the `minimumVisitLength` and `heartbeatDelay` properties of the `WebActivityTracking` instance will enable activity tracking using 'page ping' events on Web.

--- a/doc/03-tracking-events.md
+++ b/doc/03-tracking-events.md
@@ -4,9 +4,9 @@ Snowplow has been built to enable you to track a wide range of events that occur
 
 We provide several built-in event classes to help you track different kinds of events. When instantiated, their objects can be passed to the `Snowplow.track()` method to send events to the Snowplow collector. The event classes range from single purpose ones, such as `ScreenView`, to the more complex but flexible `SelfDescribing`, which can be used to track any kind of user behaviour. We strongly recommend using `SelfDescribing` for your tracking, as it allows you to design custom event types to match your business requirements. [This post](https://snowplowanalytics.com/blog/2020/01/24/re-thinking-the-structure-of-event-data/) on our blog, "Re-thinking the structure of event data" might be informative here.
 
-## Auto-tracked events
+## Auto-tracked view events
 
-There is also an option to automatically track view events when currently active pages change through the [Navigator API](https://api.flutter.dev/flutter/widgets/Navigator-class.html).
+There is an option to automatically track view events when currently active pages change through the [Navigator API](https://api.flutter.dev/flutter/widgets/Navigator-class.html).
 
 To activate this feature, one has to register a `SnowplowObserver` retrieved from the tracker instance using `SnowplowTracker.getObserver()`. The retrieved observer can be added to `navigatorObservers` in `MaterialApp`:
 

--- a/doc/03-tracking-events.md
+++ b/doc/03-tracking-events.md
@@ -4,6 +4,54 @@ Snowplow has been built to enable you to track a wide range of events that occur
 
 We provide several built-in event classes to help you track different kinds of events. When instantiated, their objects can be passed to the `Snowplow.track()` method to send events to the Snowplow collector. The event classes range from single purpose ones, such as `ScreenView`, to the more complex but flexible `SelfDescribing`, which can be used to track any kind of user behaviour. We strongly recommend using `SelfDescribing` for your tracking, as it allows you to design custom event types to match your business requirements. [This post](https://snowplowanalytics.com/blog/2020/01/24/re-thinking-the-structure-of-event-data/) on our blog, "Re-thinking the structure of event data" might be informative here.
 
+## Auto-tracked events
+
+There is also an option to automatically track view events when currently active pages change through the [Navigator API](https://api.flutter.dev/flutter/widgets/Navigator-class.html).
+
+To activate this feature, one has to register a `SnowplowObserver` retrieved from the tracker instance using `SnowplowTracker.getObserver()`. The retrieved observer can be added to `navigatorObservers` in `MaterialApp`:
+
+```dart
+MaterialApp(
+  navigatorObservers: [
+    tracker.getObserver()
+  ],
+  ...
+);
+```
+
+If using the `Router` API with the `MaterialApp.router` constructor, add the observer to the `observers` of your `Navigator` instance, e.g.:
+
+```dart
+Navigator(
+  observers: [tracker.getObserver()],
+  ...
+);
+```
+
+The `SnowplowObserver` automatically tracks `PageViewEvent` and `ScreenView` events when the currently active `ModalRoute` of the navigator changes.
+
+By default, `ScreenView` events are tracked on all platforms. In case `TrackerConfiguration.webActivityTracking` is configured when creating the tracker, `PageViewEvent` events will be tracked on Web instead of `ScreenView` events (`ScreenView` events will still be tracked on other platforms).
+
+The `SnowplowTracker.getObserver()` function takes an optional `nameExtractor` function as argument which is used to extract a name from new routes that is used in tracked `ScreenView` or `PageViewEvent` events.
+
+The following operations will result in tracking a view event:
+
+```dart
+Navigator.pushNamed(context, '/contact/123');
+
+Navigator.push<void>(context, MaterialPageRoute(
+  settings: RouteSettings(name: '/contact/123'),
+  builder: (_) => ContactDetail(123)));
+
+Navigator.pushReplacement<void>(context, MaterialPageRoute(
+  settings: RouteSettings(name: '/contact/123'),
+  builder: (_) => ContactDetail(123)));
+
+Navigator.pop(context);
+```
+
+## Manually-tracked events
+
 Event classes supported by the Flutter Tracker:
 
 | Method | Event type tracked |
@@ -184,50 +232,4 @@ tracker.track(ConsentWithdrawn(
     name: 'name1',
     documentDescription: 'description1',
 ));
-```
-
-## Automatically tracking view events using navigator observer
-
-There is also an option to automatically track view events when currently active pages change through the [Navigator API](https://api.flutter.dev/flutter/widgets/Navigator-class.html).
-
-To activate this feature, one has to register a `SnowplowObserver` retrieved from the tracker instance using `SnowplowTracker.getObserver()`. The retrieved observer can be added to `navigatorObservers` in `MaterialApp`:
-
-```dart
-MaterialApp(
-  navigatorObservers: [
-    tracker.getObserver()
-  ],
-  ...
-);
-```
-
-If using the `Router` API with the `MaterialApp.router` constructor, add the observer to the `observers` of your `Navigator` instance, e.g.:
-
-```dart
-Navigator(
-  observers: [tracker.getObserver()],
-  ...
-);
-```
-
-The `SnowplowObserver` automatically tracks `PageViewEvent` and `ScreenView` events when the currently active `ModalRoute` of the navigator changes.
-
-By default, `ScreenView` events are tracked on all platforms. In case `TrackerConfiguration.webActivityTracking` is configured when creating the tracker, `PageViewEvent` events will be tracked on Web instead of `ScreenView` events (`ScreenView` events will still be tracked on other platforms).
-
-The `SnowplowTracker.getObserver()` function takes an optional `nameExtractor` function as argument which is used to extract a name from new routes that is used in tracked `ScreenView` or `PageViewEvent` events.
-
-The following operations will result in tracking a view event:
-
-```dart
-Navigator.pushNamed(context, '/contact/123');
-
-Navigator.push<void>(context, MaterialPageRoute(
-  settings: RouteSettings(name: '/contact/123'),
-  builder: (_) => ContactDetail(123)));
-
-Navigator.pushReplacement<void>(context, MaterialPageRoute(
-  settings: RouteSettings(name: '/contact/123'),
-  builder: (_) => ContactDetail(123)));
-
-Navigator.pop(context);
 ```

--- a/example/integration_test/configuration_test.dart
+++ b/example/integration_test/configuration_test.dart
@@ -158,7 +158,7 @@ void main() {
         expect(appContexts.isNotEmpty, isTrue);
 
         Iterable screenContexts = events[0]['event']['contexts']['data']
-            .where((x) => x['schema'].toString().contains('screen\\/'));
+            .where((x) => x['schema'].toString().contains('screen'));
         expect(screenContexts.isNotEmpty, isTrue);
       }
       return true;
@@ -188,7 +188,7 @@ void main() {
         expect(appContexts.isEmpty, isTrue);
 
         Iterable screenContexts = events[0]['event']['contexts']['data']
-            .where((x) => x['schema'].toString().contains('screen\\/'));
+            .where((x) => x['schema'].toString().contains('screen'));
         expect(screenContexts.isEmpty, isTrue);
       }
       return true;

--- a/example/integration_test/configuration_test.dart
+++ b/example/integration_test/configuration_test.dart
@@ -9,6 +9,8 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
+import 'package:flutter/foundation.dart' show kIsWeb;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -139,6 +141,11 @@ void main() {
 
   testWidgets("screenContext and applicationContext on by default",
       (WidgetTester tester) async {
+    // screenContext/applicationContext are not available on web
+    if (kIsWeb) {
+      return;
+    }
+
     SnowplowTracker tracker = await Snowplow.createTracker(
         namespace: 'screen-on', endpoint: SnowplowTests.microEndpoint);
 
@@ -149,18 +156,14 @@ void main() {
       if (events.length != 1) {
         return false;
       }
-      String eventType =
-          events[0]['event']['v_tracker'].toString().substring(0, 2);
-      // screenContext/applicationContext are not available on web
-      if (eventType == 'and' || eventType == 'ios') {
-        Iterable appContexts = events[0]['event']['contexts']['data']
-            .where((x) => x['schema'].toString().contains('application'));
-        expect(appContexts.isNotEmpty, isTrue);
 
-        Iterable screenContexts = events[0]['event']['contexts']['data']
-            .where((x) => x['schema'].toString().contains('screen'));
-        expect(screenContexts.isNotEmpty, isTrue);
-      }
+      Iterable appContexts = events[0]['event']['contexts']['data']
+          .where((x) => x['schema'].toString().contains('application'));
+      expect(appContexts.isNotEmpty, isTrue);
+
+      Iterable screenContexts = events[0]['event']['contexts']['data']
+          .where((x) => x['schema'].toString().contains('screen'));
+      expect(screenContexts.isNotEmpty, isTrue);
       return true;
     });
 
@@ -179,18 +182,14 @@ void main() {
       if (events.length != 1) {
         return false;
       }
-      String eventType =
-          events[0]['event']['v_tracker'].toString().substring(0, 2);
-      // screenContext/applicationContext are not available on web
-      if (eventType == 'and' || eventType == 'ios') {
-        Iterable appContexts = events[0]['event']['contexts']['data']
-            .where((x) => x['schema'].toString().contains('application'));
-        expect(appContexts.isEmpty, isTrue);
 
-        Iterable screenContexts = events[0]['event']['contexts']['data']
-            .where((x) => x['schema'].toString().contains('screen'));
-        expect(screenContexts.isEmpty, isTrue);
-      }
+      Iterable appContexts = events[0]['event']['contexts']['data']
+          .where((x) => x['schema'].toString().contains('application'));
+      expect(appContexts.isEmpty, isTrue);
+
+      Iterable screenContexts = events[0]['event']['contexts']['data']
+          .where((x) => x['schema'].toString().contains('screen'));
+      expect(screenContexts.isEmpty, isTrue);
       return true;
     });
   });

--- a/example/integration_test/helpers.dart
+++ b/example/integration_test/helpers.dart
@@ -44,12 +44,12 @@ class SnowplowTests {
 
   static Future<bool> checkMicroResponse(
       String api, bool Function(dynamic body) validation) async {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 20; i++) {
       final response = await http.get(Uri.parse(microEndpoint + api));
       if (validation(jsonDecode(response.body))) {
         return true;
       }
-      await Future.delayed(const Duration(seconds: 1), () {});
+      await Future.delayed(const Duration(milliseconds: 100), () {});
     }
     return false;
   }

--- a/example/integration_test/helpers.dart
+++ b/example/integration_test/helpers.dart
@@ -44,12 +44,12 @@ class SnowplowTests {
 
   static Future<bool> checkMicroResponse(
       String api, bool Function(dynamic body) validation) async {
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < 10; i++) {
       final response = await http.get(Uri.parse(microEndpoint + api));
       if (validation(jsonDecode(response.body))) {
         return true;
       }
-      await Future.delayed(const Duration(milliseconds: 100), () {});
+      await Future.delayed(const Duration(seconds: 1), () {});
     }
     return false;
   }

--- a/ios/Classes/readers/configurations/TrackerConfigurationReader.swift
+++ b/ios/Classes/readers/configurations/TrackerConfigurationReader.swift
@@ -52,7 +52,7 @@ extension TrackerConfigurationReader {
         if let gc = self.geoLocationContext { trackerConfig.geoLocationContext(gc) }
         if let sc = self.sessionContext { trackerConfig.sessionContext(sc) }
         if let scr = self.screenContext { trackerConfig.screenContext(scr) }
-        if let ac = self.sessionContext { trackerConfig.applicationContext(ac) }
+        if let ac = self.applicationContext { trackerConfig.applicationContext(ac) }
 
         return trackerConfig
     }

--- a/ios/Classes/readers/configurations/TrackerConfigurationReader.swift
+++ b/ios/Classes/readers/configurations/TrackerConfigurationReader.swift
@@ -19,6 +19,8 @@ struct TrackerConfigurationReader: Decodable {
     let platformContext: Bool?
     let geoLocationContext: Bool?
     let sessionContext: Bool?
+    let screenContext: Bool?
+    let applicationContext: Bool?
     
     var devicePlatformType: DevicePlatform? {
         if let devicePlatform = self.devicePlatform { return SPStringToDevicePlatform(devicePlatform) }
@@ -31,8 +33,6 @@ extension TrackerConfigurationReader {
         let trackerConfig = TrackerConfiguration()
         trackerConfig.trackerVersionSuffix(TrackerVersion.TRACKER_VERSION)
 
-        trackerConfig.applicationContext(false)
-        trackerConfig.screenContext(false)
         trackerConfig.screenViewAutotracking(false)
         trackerConfig.lifecycleAutotracking(false)
         trackerConfig.installAutotracking(false)
@@ -51,6 +51,8 @@ extension TrackerConfigurationReader {
         if let pc = self.platformContext { trackerConfig.platformContext(pc) }
         if let gc = self.geoLocationContext { trackerConfig.geoLocationContext(gc) }
         if let sc = self.sessionContext { trackerConfig.sessionContext(sc) }
+        if let scr = self.screenContext { trackerConfig.screenContext(scr) }
+        if let ac = self.sessionContext { trackerConfig.applicationContext(ac) }
 
         return trackerConfig
     }

--- a/lib/configurations/tracker_configuration.dart
+++ b/lib/configurations/tracker_configuration.dart
@@ -56,6 +56,16 @@ class TrackerConfiguration {
   /// Only available on Web, defaults to true.
   final bool? webPageContext;
 
+  /// Indicates whether screen context should be attached to tracked events.
+  ///
+  /// Defaults to true on iOS and Android. Not available on Web.
+  final bool? screenContext;
+
+  /// Indicates whether application context should be attached to tracked events.
+  ///
+  /// Defaults to true on iOS and Android. Not available on Web.
+  final bool? applicationContext;
+
   /// Configuration for activity tracking on the Web and use of `PageViewEvent`
   /// events in auto tracking from [SnowplowObserver] observers.
   final WebActivityTracking? webActivityTracking;
@@ -68,6 +78,8 @@ class TrackerConfiguration {
       this.geoLocationContext,
       this.sessionContext,
       this.webPageContext,
+      this.screenContext,
+      this.applicationContext,
       this.webActivityTracking});
 
   Map<String, Object?> toMap() {
@@ -79,6 +91,8 @@ class TrackerConfiguration {
       'geoLocationContext': geoLocationContext,
       'sessionContext': sessionContext,
       'webPageContext': webPageContext,
+      'screenContext': screenContext,
+      'applicationContext': applicationContext,
       'webActivityTracking': webActivityTracking?.toMap(),
     };
     conf.removeWhere((key, value) => value == null);

--- a/test/snowplow_test.dart
+++ b/test/snowplow_test.dart
@@ -50,7 +50,10 @@ void main() {
         namespace: 'tns1',
         endpoint: 'https://snowplowanalytics.com',
         trackerConfig: const TrackerConfiguration(
-            devicePlatform: DevicePlatform.iot, base64Encoding: true),
+            devicePlatform: DevicePlatform.iot,
+            base64Encoding: true,
+            screenContext: false,
+            applicationContext: true),
         gdprConfig: const GdprConfiguration(
             basisForProcessing: 'b',
             documentId: 'd',
@@ -62,7 +65,12 @@ void main() {
         isMethodCall('createTracker', arguments: {
           'namespace': 'tns1',
           'networkConfig': {'endpoint': 'https://snowplowanalytics.com'},
-          'trackerConfig': {'devicePlatform': 'iot', 'base64Encoding': true},
+          'trackerConfig': {
+            'devicePlatform': 'iot',
+            'base64Encoding': true,
+            'screenContext': false,
+            'applicationContext': true
+          },
           'gdprConfig': {
             'basisForProcessing': 'b',
             'documentId': 'd',


### PR DESCRIPTION
For issue #27.

Allows configuration of two context entities for mobile: screenContext and applicationContext.